### PR TITLE
fix(hermes): preserve named provider when switching models

### DIFF
--- a/hermes_manager.sh
+++ b/hermes_manager.sh
@@ -227,7 +227,10 @@ try:
         print(json.dumps(out))
     elif action == "switch":
         n, u, k, m = sys.argv[3:7]
-        data['model'] = {"default": m, "provider": "custom", "base_url": u, "api_key": k}
+        # Preserve the selected named custom provider. A bare "custom" route
+        # is ambiguous when multiple entries share a base URL but use
+        # different API keys or have different model entitlements.
+        data['model'] = {"default": m, "provider": f"custom:{n}", "base_url": u, "api_key": k}
         save(data)
 
 except Exception as e:


### PR DESCRIPTION
## Summary
- preserve the selected `custom_providers` entry when switching models
- write `model.provider` as `custom:<provider-name>` instead of the ambiguous bare `custom`

## Why
When multiple named providers share one base URL but use different API keys or model entitlements, the bare `custom` route loses the selected provider identity. Hermes may then resolve a different credential for the same endpoint, producing a misleading `model_not_found` error.

For example, two entries can share `https://api.s1x.io/v1` while one key is entitled to GPT models and another is entitled to DeepSeek. Selecting the DeepSeek entry must retain that entry's provider name.

## Verification
- `bash -n hermes_manager.sh`
- exercised the embedded `config_tool switch` handler against an isolated config with two providers on the same URL but different keys; verified it writes `custom:s1x-deepseek/deepseek-v4-flash`
